### PR TITLE
Fix a couple of format issues

### DIFF
--- a/net-speed.tmux
+++ b/net-speed.tmux
@@ -3,11 +3,15 @@
 SDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 source "$SDIR/scripts/helpers.sh"
 
-upload_speed_format=$(get_tmux_option   @upload_speed_format   "%7s")
-download_speed_format=$(get_tmux_option @download_speed_format "%7s")
+upload_speed_format()   {
+    get_tmux_option @upload_speed_format   "%%7s"
+}
+download_speed_format() {
+    get_tmux_option @download_speed_format "%%7s"
+}
 
-upload_speed="#($SDIR/scripts/net-speed.sh   tx_bytes $(upload_speed_format))"
-download_speed="#($SDIR/scripts/net-speed.sh rx_bytes $(download_speed_format))"
+upload_speed="#($SDIR/scripts/net-speed.sh   tx_bytes '$(upload_speed_format)')"
+download_speed="#($SDIR/scripts/net-speed.sh rx_bytes '$(download_speed_format)')"
 
 upload_interpolation="\#{upload_speed}"
 download_interpolation="\#{download_speed}"


### PR DESCRIPTION
First, thanks for this plugin, very cool! I noticed that the formatting options weren't working as expected, however, so I made a couple of small changes that seem to work for me. Let me know if I'm off base, though.

1. Apparently `%7s` gets interpreted by tmux somehow, so you have to
   escape it with `%%7s`

2. The approach of calling `$(upload_speed_format)` when
   `upload_speed_format` is defined as

```
upload_speed_format="$(get_tmux_option ...)"
```

  tries to evaluate the output of `get_tmux_option`. I made
  `upload_speed_format` a function instead, which evaluates properly.

  Before this, my status line shows this:

```
$ tmux show -g status-right
status-right "#(/Users/joel/.tmux/plugins/tmux-net-speed/scripts/net-speed.sh   tx_bytes )"
```

  Note that the format string is missing altogether, because the
  `$(upload_speed_format)` failed. With the fix, I see this:

```
$ tmux show -g status-right
status-right "#(/Users/joel/.tmux/plugins/tmux-net-speed/scripts/net-speed.sh   tx_bytes '%%-7s')"
```

  which works correctly.

My tmux version is:

```sh
$ tmux -V
tmux 3.1c
```

Edit: forgot to mention, I use

```
set -g @upload_speed_format "%%-7s"
```
 
in my `.tmux.conf`