### PR TITLE
fix: awk use the scientific notation

### DIFF
--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -27,7 +27,7 @@ get_os() {
 }
 
 sum_column() {
-    awk '{sum += $1;}END{print sum;}'
+    awk '{sum += $1;}END{printf("%.0f",sum);}'
 }
 
 # ref: https://unix.stackexchange.com/a/98790 @John


### PR DESCRIPTION
It will occur `invalid arithmetic operator` error when awk returns the integer scientific notation for mathematical operations in bash.