### PR TITLE
feat: add @net_speed_interfaces option for interface selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # tmux-net-speed
 
 [![TPM](https://img.shields.io/badge/tpm--support-true-blue)](https://github.com/tmux-plugins/tpm)
-[![Awesome](https://img.shields.io/badge/Awesome-tmux-d07cd0?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAABVklEQVRIS+3VvWpVURDF8d9CRAJapBAfwWCt+FEJthIUUcEm2NgIYiOxsrCwULCwktjYKSgYLfQF1JjCNvoMNhYRCwOO7HAiVw055yoBizvN3nBmrf8+M7PZsc2RbfY3AfRWeNMSVdUlHEzS1t6oqvt4n+TB78l/AKpqHrdwLcndXndU1WXcw50k10c1PwFV1fa3cQVzSR4PMd/IqaoLeIj2N1eTfG/f1gFVtQMLOI+zSV6NYz4COYFneIGLSdZSVbvwCMdxMsnbvzEfgRzCSyzjXAO8xlHcxMq/mI9oD+AGlhqgxjD93OVOD9TUuICdXd++/VeAVewecKKv2NPlfcHUAM1qK9FTnBmQvJjkdDfWzzE7QPOkAfZiEce2ECzhVJJPHWAfGuTwFpo365pO0NYjmEFr5Uas4SPeJfll2rqb38Z7/yaaD+0eNM3kPejt86REvSX6AamgdXkgoxLxAAAAAElFTkSuQmCC)](https://github.com/rothgar/awesome-tmux)
 [![License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://wfxr.mit-license.org/2018)
 
 A tmux plugin for displaying network upload and download speed in the status bar.
@@ -47,6 +46,7 @@ set -g @tmux_power_show_download_speed true
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `@net_speed_interfaces` | *(empty)* | Space-separated list of interfaces to monitor. If empty, all non-virtual interfaces are used. |
 | `@upload_speed_format` | `%7s` | printf format string for upload speed |
 | `@download_speed_format` | `%7s` | printf format string for download speed |
 

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2218
 
 set_tmux_option() {
     local option="$1"
@@ -31,17 +32,35 @@ get_os() {
 
 IGNORED_IFACES='^(lo|docker|veth|br-|virbr|tun|vnet)'
 
+# Shared awk snippet: precompute whitelist in BEGIN, skip_iface() returns 1 if
+# the interface should be excluded.
+AWK_IFACE_FILTER='
+BEGIN {
+    if (ifaces != "") {
+        n = split(ifaces, _arr)
+        for (i = 1; i <= n; i++) wanted[_arr[i]] = 1
+    }
+}
+function skip_iface(name) {
+    if (ifaces != "") return !(name in wanted)
+    return (name ~ ignore)
+}
+'
+
 # $1: rx_bytes/tx_bytes
 get_bytes() {
     local field=$1
     local os
     os=$(get_os)
+    local interfaces
+    interfaces=$(get_tmux_option "@net_speed_interfaces" "")
     case $os in
         linux)
-            awk -v field="$field" -v ignore="$IGNORED_IFACES" '
+            awk -v field="$field" -v ignore="$IGNORED_IFACES" -v ifaces="$interfaces" \
+                "$AWK_IFACE_FILTER"'
             NR > 2 {
                 gsub(/:/, "", $1)
-                if ($1 ~ ignore) next
+                if (skip_iface($1)) next
                 if (field == "rx_bytes") sum += $2
                 else if (field == "tx_bytes") sum += $10
             }
@@ -57,9 +76,10 @@ get_bytes() {
             esac
             netstat $netstat_flags |
                 awk -v field="$field" -v ignore="$IGNORED_IFACES" \
-                    -v rx_col="$rx_col" -v tx_col="$tx_col" '
+                    -v rx_col="$rx_col" -v tx_col="$tx_col" -v ifaces="$interfaces" \
+                    "$AWK_IFACE_FILTER"'
                 /:/ && !seen[$1]++ {
-                    if ($1 ~ ignore) next
+                    if (skip_iface($1)) next
                     rx += $rx_col; tx += $tx_col
                 }
                 END { printf "%.0f", (field == "rx_bytes") ? rx : tx }


### PR DESCRIPTION
## Summary
- Add `@net_speed_interfaces` tmux option that accepts a space-separated list of interface names to monitor
- When set, only the specified interfaces are counted; when unset, existing behavior (all non-virtual interfaces) is preserved
- Extract shared awk filtering logic into `AWK_IFACE_FILTER` to avoid duplication between Linux and BSD branches

Closes #7

## Test plan
- [x] Existing tests pass (`test_get_bytes.sh`, `test_bytestohuman.sh`)
- [x] shellcheck passes
- [ ] Verify default behavior unchanged (no option set → same as before)
- [ ] Verify `tmux set -g @net_speed_interfaces "lo"` shows ~0 traffic
- [ ] Verify `tmux set -g @net_speed_interfaces "eth0 wlan0"` shows combined traffic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new option to specify which network interfaces to monitor (accepts a list; when empty, monitors all non-virtual interfaces).
  * Interface selection is now applied consistently across platforms.

* **Documentation**
  * Updated docs with the new option description and an example showing how to configure interfaces and adjust speed format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->